### PR TITLE
adding in logic to work with rot.js Cellular type maps

### DIFF
--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -62,7 +62,12 @@ module.exports = function generator (options = {}) {
       weightedRoomsTable
     })
     try {
-      map.create(mapper)
+      if (type == "Cellular") {
+        mapper.randomize(randomize);
+        for (var i=0; i<passes; i++) map.create(mapper);
+      } else {
+        map.create(mapper);
+      }
     } catch (error) {
       const msg = `Error when creating map. Please ensure options are correct for ROT-js map type ${type}.`
       console.log(msg)

--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -29,6 +29,11 @@ module.exports = function generator (options = {}) {
     corridorLengthMaximum,
     regularity,
     weightedRoomsTable,
+    randomize,
+    passes,
+    born = [5, 6, 7, 8],
+    survive = [4, 5, 6, 7, 8],
+    topology= 8
   } = options
 
   // Make just a 2D map as MVP.
@@ -51,6 +56,11 @@ module.exports = function generator (options = {}) {
       timeLimit,
       genericRoomTitle,
       genericRoomDesc,
+      randomize,
+      passes,
+      born = [5, 6, 7, 8],
+      survive = [4, 5, 6, 7, 8],
+      topology= 8
     })
 
     const mapper = new Mapper(width, height, _mapperOptions)


### PR DESCRIPTION
This adds in logic to work for Cellular type map parameters

Which you can set when calling Axolemma.generate
passes = 6   //number of passes to run the Cellular growth algorithm
randomize = .54  //number between 0 and 1 for the chance of each room starting out with a 'cell'

This doesn't account for several additional Cellular type parameters, I'd like to incorporate later.
	born:
	survive:
	topology: 
